### PR TITLE
Add jump to nearest annotation feature (v0.1.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ After installing napari-simpleannotate, launch napari and navigate to `Plugins >
 2. **Navigation**:
    - Use napari's time slider to navigate frames
    - Frame counter shows current position: "Frame: X/Y"
+   - **Keyboard shortcuts**: Q (previous annotation), W (next annotation)
+   - Click navigation buttons to jump to nearest annotations
    - Video performance optimized with LRU cache and parallel prefetching
 
 3. **Frame-Aware Annotation**:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "zarr",
     "numcodecs",
 ]
-version = "0.1.1"
+version = "0.1.2"
 
 [project.optional-dependencies]
 testing = [

--- a/src/napari_simpleannotate/_bbox_video_widget.py
+++ b/src/napari_simpleannotate/_bbox_video_widget.py
@@ -336,7 +336,7 @@ class BboxVideoQWidget(QWidget):
         self.jump_prev_button = QPushButton("← Previous Annotation (Q)", self)
         self.jump_prev_button.clicked.connect(self.jump_to_previous_annotation)
         self.jump_prev_button.setEnabled(False)
-        
+
         self.jump_next_button = QPushButton("Next Annotation (W) →", self)
         self.jump_next_button.clicked.connect(self.jump_to_next_annotation)
         self.jump_next_button.setEnabled(False)
@@ -422,10 +422,10 @@ class BboxVideoQWidget(QWidget):
 
         # Connect to shape data change events
         shapes_layer.events.data.connect(self.on_shape_added)
-        
+
         # Bind keyboard shortcuts for navigation
-        self.viewer.bind_key('q', self.jump_to_previous_annotation)
-        self.viewer.bind_key('w', self.jump_to_next_annotation)
+        self.viewer.bind_key("q", self.jump_to_previous_annotation)
+        self.viewer.bind_key("w", self.jump_to_next_annotation)
 
     def openVideo(self):
         """Open video file using file dialog."""
@@ -798,7 +798,7 @@ class BboxVideoQWidget(QWidget):
 
             # 最初のフレームに移動
             self.viewer.dims.current_step = (0,) + self.viewer.dims.current_step[1:]
-            
+
             # Enable navigation buttons
             self.jump_prev_button.setEnabled(True)
             self.jump_next_button.setEnabled(True)
@@ -1286,24 +1286,24 @@ class BboxVideoQWidget(QWidget):
         """Jump to the nearest annotation before the current frame."""
         if not self.video_layer:
             return
-        
+
         shapes_layer = self.viewer.layers["bbox_layer"]
         if len(shapes_layer.data) == 0:
             return
-        
+
         # Get current frame
         current_frame = self.current_frame
-        
+
         # Get all annotated frames
         annotated_frames = set()
         for shape in shapes_layer.data:
             if len(shape) == 4:  # Rectangle shape
                 frame = int(shape[0][0])
                 annotated_frames.add(frame)
-        
+
         # Find previous annotated frames
         previous_frames = [f for f in annotated_frames if f < current_frame]
-        
+
         if previous_frames:
             # Jump to the nearest previous frame
             target_frame = max(previous_frames)
@@ -1311,29 +1311,29 @@ class BboxVideoQWidget(QWidget):
             print(f"Jumped to previous annotation at frame {target_frame}")
         else:
             print("No previous annotations found")
-    
+
     def jump_to_next_annotation(self, viewer=None):
         """Jump to the nearest annotation after the current frame."""
         if not self.video_layer:
             return
-        
+
         shapes_layer = self.viewer.layers["bbox_layer"]
         if len(shapes_layer.data) == 0:
             return
-        
+
         # Get current frame
         current_frame = self.current_frame
-        
+
         # Get all annotated frames
         annotated_frames = set()
         for shape in shapes_layer.data:
             if len(shape) == 4:  # Rectangle shape
                 frame = int(shape[0][0])
                 annotated_frames.add(frame)
-        
+
         # Find next annotated frames
         next_frames = [f for f in annotated_frames if f > current_frame]
-        
+
         if next_frames:
             # Jump to the nearest next frame
             target_frame = min(next_frames)


### PR DESCRIPTION
## Summary
- Added keyboard shortcuts Q/W to jump between annotations in video
- Added navigation buttons with visual feedback
- Improves annotation workflow efficiency

## Changes
- **New Features**:
  - Jump to previous annotation (Q key)
  - Jump to next annotation (W key)
  - Navigation buttons in UI
- **Documentation**: Updated README with new shortcuts
- **Version**: Bumped to 0.1.2

## Test Plan
- [x] Load video file
- [x] Create annotations on different frames
- [x] Test Q key to jump to previous annotation
- [x] Test W key to jump to next annotation
- [x] Test navigation buttons
- [x] Verify buttons are disabled when no video loaded