### PR TITLE
Use the configured edge_width when reloading an image with annotations

### DIFF
--- a/src/napari_simpleannotate/_bbox_widget.py
+++ b/src/napari_simpleannotate/_bbox_widget.py
@@ -331,7 +331,7 @@ class BboxQWidget(QWidget):
                         self.numbers.append(int(class_id))
                         classes.append(str(int(class_id)) + ": ")
                 shapes_layer = self.viewer.layers["bbox_layer"]
-                shapes_layer.data = shapes_data
+                shapes_layer.add_rectangles(shapes_data)
                 shapes_layer.features["class"] = classes
                 self.sort_classlist()
                 shapes_layer.refresh_text()

--- a/src/napari_simpleannotate/_bbox_widget.py
+++ b/src/napari_simpleannotate/_bbox_widget.py
@@ -331,6 +331,7 @@ class BboxQWidget(QWidget):
                         self.numbers.append(int(class_id))
                         classes.append(str(int(class_id)) + ": ")
                 shapes_layer = self.viewer.layers["bbox_layer"]
+                shapes_layer.data = []
                 shapes_layer.add_rectangles(shapes_data)
                 shapes_layer.features["class"] = classes
                 self.sort_classlist()


### PR DESCRIPTION
When reloading an image the edge_width set in napari is not respected in the display of the bounding boxes. Using the method add_rectangles when loading the annotations, instead of setting the data attribute of the shapes layer directly, solves the problem. 

In our use case we have 9 classes of cells. The cells need to be visible in the bounding boxes.  We want to use transparent bounding boxes, for which only their borders are displayed, but with a larger width, so that they are visible at the zoom levels we use. This little change would allow us exactly to do what we want, and should not have any other consequences.

