### PR TITLE
Fix feature length mismatch when adding tracking results

### DIFF
--- a/src/napari_simpleannotate/_bbox_video_widget.py
+++ b/src/napari_simpleannotate/_bbox_video_widget.py
@@ -2117,11 +2117,12 @@ class BboxVideoQWidget(QWidget):
 
         # Add all rectangles at once
         if rectangles_to_add:
-            shapes_layer.add_rectangles(rectangles_to_add)
-
-            # Update features after adding all shapes
+            # Get current features BEFORE adding rectangles
+            # (add_rectangles may auto-extend features, causing double-counting)
             current_classes = list(shapes_layer.features.get("class", []))
             current_frames = list(shapes_layer.features.get("frame", []))
+
+            shapes_layer.add_rectangles(rectangles_to_add)
 
             current_classes.extend(classes_to_add)
             current_frames.extend(frames_to_add)


### PR DESCRIPTION
## Summary
- Fix bug where class information was lost when adding tracking results
- Get current features BEFORE calling `add_rectangles()` to avoid double-counting

## Problem
When tracking results were added via `_on_tracking_result()`, the following warning appeared:
```
WARNING : Feature length mismatch. Shapes: 73, Classes: 74
```

This was caused by napari's `add_rectangles()` auto-extending the features array internally. The code then called `features.get()` after `add_rectangles()`, getting the already-extended array, and then `extend()` added duplicate entries.

## Test plan
- [x] Run tracking and verify "Feature length mismatch" warning no longer appears
- [x] Verify tracked bboxes retain correct class information after tracking