### PR TITLE
Usability ameliorations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "zarr",
     "numcodecs",
     "opencv-contrib-python",
+    "appdirs",
 ]
 version = "0.1.5"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "zarr",
     "numcodecs",
     "opencv-contrib-python",
-    "appdirs",
+    "platformdirs",
 ]
 version = "0.1.5"
 

--- a/src/napari_simpleannotate/_bbox_widget.py
+++ b/src/napari_simpleannotate/_bbox_widget.py
@@ -124,11 +124,11 @@ class BboxQWidget(QWidget):
         self.viewer.add_image(np.zeros((10, 10)), name="image_layer")
         self.viewer.add_shapes(name="bbox_layer", features=self.features, text=self.text)
         self.viewer.layers["bbox_layer"].events.data.connect(self.annotationsChanged)
+        self.read_display_settings()
+        self.apply_display_settings()
         self.viewer.layers["bbox_layer"].events.current_edge_color.connect(self.bounding_box_display_changed)
         self.viewer.layers["bbox_layer"].events.current_face_color.connect(self.bounding_box_display_changed)
         self.viewer.layers["bbox_layer"].events.edge_width.connect(self.bounding_box_display_changed)
-        self.read_display_settings()
-        self.apply_display_settings()
         # self.viewer.layers["bbox_layer"].mouse_drag_callbacks.append(self.add_size)
 
     def annotationsChanged(self):
@@ -140,22 +140,21 @@ class BboxQWidget(QWidget):
         if self.classlistWidget.currentItem():
             shapes_layer.feature_defaults["class"] = self.classlistWidget.currentItem().text()
 
-
     def bounding_box_display_changed(self, event):
         shapes_layer = self.viewer.layers["bbox_layer"]
-        self.display_settings = {"edge_color": str(shapes_layer.current_edge_color),
-                           "face_color": str(shapes_layer.current_face_color),
-                           "edge_width": int(shapes_layer.current_edge_width)}
-        with open(self.options_path, 'w') as file:
+        self.display_settings = {
+            "edge_color": str(shapes_layer.current_edge_color),
+            "face_color": str(shapes_layer.current_face_color),
+            "edge_width": int(shapes_layer.current_edge_width),
+        }
+        with open(self.options_path, "w") as file:
             yaml.dump(self.display_settings, file)
-
 
     def read_display_settings(self):
         if not os.path.exists(self.options_path):
             return
-        with open(self.options_path, 'r') as file:
+        with open(self.options_path, "r") as file:
             self.display_settings = yaml.safe_load(file)
-
 
     def apply_display_settings(self):
         if not self.display_settings:
@@ -324,7 +323,6 @@ class BboxQWidget(QWidget):
                 self.countListWidget.addItem(f"0")
             self.sort_classlist()
         self.update_list_colors_and_class_count()
-
 
     def showSaveChangesDialog(self):
         popup = QMessageBox(self)
@@ -538,7 +536,7 @@ class BboxQWidget(QWidget):
             annotationsPath = os.path.splitext(path)[0] + ".txt"
             if not os.path.exists(annotationsPath):
                 continue
-            with open(annotationsPath, 'r') as file:
+            with open(annotationsPath, "r") as file:
                 lines = file.readlines()
             if len(lines) == 0:
                 continue
@@ -551,8 +549,7 @@ class BboxQWidget(QWidget):
             if item.isSelected() and self.dirty:
                 item.setForeground(QBrush(QColorConstants.Red))
         self.countListWidget.clear()
-        counts = ['0'] * len(self.class_counts)
+        counts = ["0"] * len(self.class_counts)
         self.countListWidget.addItems(counts)
         for key, value in self.class_counts.items():
             self.countListWidget.item(key).setText(str(value))
-

--- a/src/napari_simpleannotate/_bbox_widget.py
+++ b/src/napari_simpleannotate/_bbox_widget.py
@@ -544,7 +544,7 @@ class BboxQWidget(QWidget):
                 continue
             for line in lines:
                 class_id = int(line.split()[0])
-                if not class_id in self.class_counts.keys():
+                if not class_id in self.class_counts:
                     self.class_counts[class_id] = 0
                 self.class_counts[class_id] = self.class_counts[class_id] + 1
             item.setForeground(QBrush(QColorConstants.Green))

--- a/src/napari_simpleannotate/_bbox_widget.py
+++ b/src/napari_simpleannotate/_bbox_widget.py
@@ -6,7 +6,8 @@ import napari
 import numpy as np
 import skimage.io
 import yaml
-import appdirs
+import platformdirs
+from PyQt5.QtCore import QItemSelectionModel
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QAbstractItemView,
@@ -50,7 +51,6 @@ class BboxQWidget(QWidget):
         # Create a list widget for displaying the list of opened files
         self.listWidget = QListWidget()
         self.listWidget.currentItemChanged.connect(self.open_image)
-
         # Create button for clear the list of opened files
         self.clear_button = QPushButton("Clear list of opened files", self)
         self.clear_button.clicked.connect(self.listWidget.clear)
@@ -111,11 +111,12 @@ class BboxQWidget(QWidget):
             "size": 10,
             "color": "green",
         }
+        self.blockFileChanged = False
         self.numbers = []
         self.current_class_number = 0
         self.previous_contrast_limits = None
         self.display_settings = None
-        self.data_folder = appdirs.user_data_dir("simple_annotate")
+        self.data_folder = platformdirs.user_data_dir("simple_annotate")
         os.makedirs(self.data_folder, exist_ok=True)
         self.options_path = os.path.join(self.data_folder, "display_options.yaml")
 
@@ -134,7 +135,7 @@ class BboxQWidget(QWidget):
     def annotationsChanged(self):
         self.dirty = True
         item = self.listWidget.currentItem()
-        if item.isSelected() and self.dirty:
+        if item and item.isSelected() and self.dirty:
             item.setForeground(QBrush(QColorConstants.Red))
         shapes_layer = self.viewer.layers["bbox_layer"]
         if self.classlistWidget.currentItem():
@@ -328,7 +329,7 @@ class BboxQWidget(QWidget):
         popup = QMessageBox(self)
         popup.setWindowTitle("Save Changes?")
         popup.setText("Do you want to save the changes?")
-        popup.setStandardButtons(QMessageBox.Yes | QMessageBox.Cancel)
+        popup.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
         return popup.exec_()
 
     def open_image(self, current_item, previous_item=None):
@@ -338,7 +339,7 @@ class BboxQWidget(QWidget):
                 response = self.showSaveChangesDialog()
                 if response == QMessageBox.Yes:
                     self.saveAnnotationsFor(previous_item.text())
-                else:
+                elif response == QMessageBox.No:
                     self.dirty = False
         self.previous_contrast_limits = self.viewer.layers["image_layer"].contrast_limits
         """Opens an image and updates the image layer in the napari viewer."""
@@ -529,6 +530,7 @@ class BboxQWidget(QWidget):
 
     def update_list_colors_and_class_count(self):
         self.class_counts = {}
+        classes = {}
         for row in range(self.listWidget.count()):
             item = self.listWidget.item(row)
             item.setForeground(QBrush(QColorConstants.White))
@@ -536,6 +538,9 @@ class BboxQWidget(QWidget):
             annotationsPath = os.path.splitext(path)[0] + ".txt"
             if not os.path.exists(annotationsPath):
                 continue
+            classesPath = os.path.join(os.path.dirname(annotationsPath), "class.yaml")
+            if os.path.exists(classesPath):
+                classes = yaml.safe_load(open(classesPath))["names"]
             with open(annotationsPath, "r") as file:
                 lines = file.readlines()
             if len(lines) == 0:
@@ -549,7 +554,7 @@ class BboxQWidget(QWidget):
             if item.isSelected() and self.dirty:
                 item.setForeground(QBrush(QColorConstants.Red))
         self.countListWidget.clear()
-        counts = ["0"] * len(self.class_counts)
+        counts = ["0"] * len(classes)
         self.countListWidget.addItems(counts)
         for key, value in self.class_counts.items():
             self.countListWidget.item(key).setText(str(value))

--- a/src/napari_simpleannotate/_bbox_widget.py
+++ b/src/napari_simpleannotate/_bbox_widget.py
@@ -7,7 +7,6 @@ import numpy as np
 import skimage.io
 import yaml
 import platformdirs
-from PyQt5.QtCore import QItemSelectionModel
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QAbstractItemView,
@@ -540,7 +539,8 @@ class BboxQWidget(QWidget):
                 continue
             classesPath = os.path.join(os.path.dirname(annotationsPath), "class.yaml")
             if os.path.exists(classesPath):
-                classes = yaml.safe_load(open(classesPath))["names"]
+                with open(classesPath, "r") as file:
+                    classes = yaml.safe_load(file)["names"]
             with open(annotationsPath, "r") as file:
                 lines = file.readlines()
             if len(lines) == 0:

--- a/src/napari_simpleannotate/_bbox_widget.py
+++ b/src/napari_simpleannotate/_bbox_widget.py
@@ -529,18 +529,19 @@ class BboxQWidget(QWidget):
 
     def update_list_colors_and_class_count(self):
         self.class_counts = {}
-        classes = {}
+        parent = ""
+        if self.listWidget.currentItem():
+            parent = os.path.dirname(self.listWidget.currentItem().text())
         for row in range(self.listWidget.count()):
             item = self.listWidget.item(row)
             item.setForeground(QBrush(QColorConstants.White))
             path = item.text()
+            itemParent = os.path.dirname(path)
+            if itemParent != parent:
+                continue
             annotationsPath = os.path.splitext(path)[0] + ".txt"
             if not os.path.exists(annotationsPath):
                 continue
-            classesPath = os.path.join(os.path.dirname(annotationsPath), "class.yaml")
-            if os.path.exists(classesPath):
-                with open(classesPath, "r") as file:
-                    classes = yaml.safe_load(file)["names"]
             with open(annotationsPath, "r") as file:
                 lines = file.readlines()
             if len(lines) == 0:
@@ -554,7 +555,12 @@ class BboxQWidget(QWidget):
             if item.isSelected() and self.dirty:
                 item.setForeground(QBrush(QColorConstants.Red))
         self.countListWidget.clear()
-        counts = ["0"] * len(classes)
+        if not self.classlistWidget.count() > 0:
+            return
+        counts = ["0"] * self.classlistWidget.count()
         self.countListWidget.addItems(counts)
+        items_text = [self.classlistWidget.item(i).text() for i in range(self.classlistWidget.count())]
+        items_id_list = [int(item_text.split(":")[0].strip()) for item_text in items_text]
         for key, value in self.class_counts.items():
-            self.countListWidget.item(key).setText(str(value))
+            index = items_id_list.index(key)
+            self.countListWidget.item(index).setText(str(value))

--- a/src/napari_simpleannotate/_bbox_widget.py
+++ b/src/napari_simpleannotate/_bbox_widget.py
@@ -6,6 +6,7 @@ import napari
 import numpy as np
 import skimage.io
 import yaml
+import appdirs
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QAbstractItemView,
@@ -113,7 +114,10 @@ class BboxQWidget(QWidget):
         self.numbers = []
         self.current_class_number = 0
         self.previous_contrast_limits = None
-        self.displaySettings = None
+        self.display_settings = None
+        self.data_folder = appdirs.user_data_dir("simple_annotate")
+        os.makedirs(self.data_folder, exist_ok=True)
+        self.options_path = os.path.join(self.data_folder, "display_options.yaml")
 
     def initLayers(self):
         """Initializes the image and shapes layers in the napari viewer."""
@@ -123,6 +127,8 @@ class BboxQWidget(QWidget):
         self.viewer.layers["bbox_layer"].events.current_edge_color.connect(self.bounding_box_display_changed)
         self.viewer.layers["bbox_layer"].events.current_face_color.connect(self.bounding_box_display_changed)
         self.viewer.layers["bbox_layer"].events.edge_width.connect(self.bounding_box_display_changed)
+        self.read_display_settings()
+        self.apply_display_settings()
         # self.viewer.layers["bbox_layer"].mouse_drag_callbacks.append(self.add_size)
 
     def annotationsChanged(self):
@@ -135,13 +141,31 @@ class BboxQWidget(QWidget):
             shapes_layer.feature_defaults["class"] = self.classlistWidget.currentItem().text()
 
 
-    def bounding_box_display_changed(self, new):
+    def bounding_box_display_changed(self, event):
         shapes_layer = self.viewer.layers["bbox_layer"]
-        self.displaySettings = {"edge_color": shapes_layer.current_edge_color,
-                           "face_color": shapes_layer.current_face_color,
-                           "edge_width": shapes_layer.current_edge_width}
+        self.display_settings = {"edge_color": str(shapes_layer.current_edge_color),
+                           "face_color": str(shapes_layer.current_face_color),
+                           "edge_width": int(shapes_layer.current_edge_width)}
+        with open(self.options_path, 'w') as file:
+            yaml.dump(self.display_settings, file)
 
 
+    def read_display_settings(self):
+        if not os.path.exists(self.options_path):
+            return
+        with open(self.options_path, 'r') as file:
+            self.display_settings = yaml.safe_load(file)
+
+
+    def apply_display_settings(self):
+        if not self.display_settings:
+            return
+        shapes_layer = self.viewer.layers["bbox_layer"]
+        if not shapes_layer:
+            return
+        shapes_layer.current_edge_width = self.display_settings["edge_width"]
+        shapes_layer.current_face_color = self.display_settings["face_color"]
+        shapes_layer.current_edge_color = self.display_settings["edge_color"]
 
     def class_clicked(self):
         shapes_layer = self.viewer.layers["bbox_layer"]

--- a/src/napari_simpleannotate/_bbox_widget.py
+++ b/src/napari_simpleannotate/_bbox_widget.py
@@ -113,12 +113,16 @@ class BboxQWidget(QWidget):
         self.numbers = []
         self.current_class_number = 0
         self.previous_contrast_limits = None
+        self.displaySettings = None
 
     def initLayers(self):
         """Initializes the image and shapes layers in the napari viewer."""
         self.viewer.add_image(np.zeros((10, 10)), name="image_layer")
         self.viewer.add_shapes(name="bbox_layer", features=self.features, text=self.text)
         self.viewer.layers["bbox_layer"].events.data.connect(self.annotationsChanged)
+        self.viewer.layers["bbox_layer"].events.current_edge_color.connect(self.bounding_box_display_changed)
+        self.viewer.layers["bbox_layer"].events.current_face_color.connect(self.bounding_box_display_changed)
+        self.viewer.layers["bbox_layer"].events.edge_width.connect(self.bounding_box_display_changed)
         # self.viewer.layers["bbox_layer"].mouse_drag_callbacks.append(self.add_size)
 
     def annotationsChanged(self):
@@ -126,6 +130,18 @@ class BboxQWidget(QWidget):
         item = self.listWidget.currentItem()
         if item.isSelected() and self.dirty:
             item.setForeground(QBrush(QColorConstants.Red))
+        shapes_layer = self.viewer.layers["bbox_layer"]
+        if self.classlistWidget.currentItem():
+            shapes_layer.feature_defaults["class"] = self.classlistWidget.currentItem().text()
+
+
+    def bounding_box_display_changed(self, new):
+        shapes_layer = self.viewer.layers["bbox_layer"]
+        self.displaySettings = {"edge_color": shapes_layer.current_edge_color,
+                           "face_color": shapes_layer.current_face_color,
+                           "edge_width": shapes_layer.current_edge_width}
+
+
 
     def class_clicked(self):
         shapes_layer = self.viewer.layers["bbox_layer"]
@@ -214,7 +230,9 @@ class BboxQWidget(QWidget):
             return
         else:
             selected_item = self.classlistWidget.selectedItems()[0]
+            selected_index = self.classlistWidget.selectedIndexes()[0]
             self.classlistWidget.takeItem(self.classlistWidget.row(selected_item))
+            self.countListWidget.takeItem(selected_index.row())
             if button.text() == "&Yes":
                 self.sort_classlist(renumber=True)
             else:
@@ -276,9 +294,13 @@ class BboxQWidget(QWidget):
             return
         else:
             self.classlistWidget.clear()
+            self.countListWidget.clear()
             for class_id, class_name in class_data_from_yaml["names"].items():
                 self.classlistWidget.addItem(f"{class_id}: {class_name}")
+                self.countListWidget.addItem(f"0")
             self.sort_classlist()
+        self.update_list_colors_and_class_count()
+
 
     def showSaveChangesDialog(self):
         popup = QMessageBox(self)
@@ -342,11 +364,6 @@ class BboxQWidget(QWidget):
             self.sort_classlist()
         items_text = [self.classlistWidget.item(i).text() for i in range(self.classlistWidget.count())]
         self.numbers = [int(name.split(":")[0]) for name in items_text]
-        for row in range(self.classlistWidget.count()):
-            item = self.classlistWidget.item(row)
-            if item.text() == current_class:
-                self.classlistWidget.setCurrentItem(item)
-
         items_dict_with_no = {
             item_text.split(":")[0].strip(): item_text.split(":")[1].strip() for item_text in items_text
         }
@@ -383,8 +400,14 @@ class BboxQWidget(QWidget):
         else:
             shapes_layer = self.viewer.layers["bbox_layer"]
             shapes_layer.data = []
+            shapes_layer.features = shapes_layer.features.iloc[:0]
+        for row in range(self.classlistWidget.count()):
+            item = self.classlistWidget.item(row)
+            if item.text() == current_class:
+                self.classlistWidget.setCurrentItem(item)
         self.viewer.reset_view()
         self.dirty = False
+        self.update_list_colors_and_class_count()
 
     def saveAnnotations(self):
         current_image_file = self.listWidget.currentItem().text()
@@ -486,6 +509,7 @@ class BboxQWidget(QWidget):
         self.class_counts = {}
         for row in range(self.listWidget.count()):
             item = self.listWidget.item(row)
+            item.setForeground(QBrush(QColorConstants.White))
             path = item.text()
             annotationsPath = os.path.splitext(path)[0] + ".txt"
             if not os.path.exists(annotationsPath):

--- a/src/napari_simpleannotate/_bbox_widget.py
+++ b/src/napari_simpleannotate/_bbox_widget.py
@@ -2,6 +2,7 @@ import os
 from functools import partial
 from typing import TYPE_CHECKING
 
+import napari
 import numpy as np
 import skimage.io
 import yaml
@@ -20,7 +21,6 @@ from qtpy.QtWidgets import (
 )
 from qtpy.QtGui import QBrush, QColorConstants
 
-
 from ._utils import find_missing_number, save_text, xywh2xyxy
 
 if TYPE_CHECKING:
@@ -32,6 +32,7 @@ class BboxQWidget(QWidget):
         super().__init__()
         self.viewer = napari_viewer
         self.class_counts = {}
+        self.dirty = False
         self.initUI()
         self.initVariables()
         self.initLayers()
@@ -117,7 +118,14 @@ class BboxQWidget(QWidget):
         """Initializes the image and shapes layers in the napari viewer."""
         self.viewer.add_image(np.zeros((10, 10)), name="image_layer")
         self.viewer.add_shapes(name="bbox_layer", features=self.features, text=self.text)
+        self.viewer.layers["bbox_layer"].events.data.connect(self.annotationsChanged)
         # self.viewer.layers["bbox_layer"].mouse_drag_callbacks.append(self.add_size)
+
+    def annotationsChanged(self):
+        self.dirty = True
+        item = self.listWidget.currentItem()
+        if item.isSelected() and self.dirty:
+            item.setForeground(QBrush(QColorConstants.Red))
 
     def class_clicked(self):
         shapes_layer = self.viewer.layers["bbox_layer"]
@@ -272,12 +280,26 @@ class BboxQWidget(QWidget):
                 self.classlistWidget.addItem(f"{class_id}: {class_name}")
             self.sort_classlist()
 
+    def showSaveChangesDialog(self):
+        popup = QMessageBox(self)
+        popup.setWindowTitle("Save Changes?")
+        popup.setText("Do you want to save the changes?")
+        popup.setStandardButtons(QMessageBox.Yes | QMessageBox.Cancel)
+        return popup.exec_()
+
     def open_image(self, current_item, previous_item=None):
+        layer_names = [layer.name for layer in self.viewer.layers]
+        if "bbox_layer" in layer_names:
+            if self.dirty:
+                response = self.showSaveChangesDialog()
+                if response == QMessageBox.Yes:
+                    self.saveAnnotationsFor(previous_item.text())
+                else:
+                    self.dirty = False
         self.previous_contrast_limits = self.viewer.layers["image_layer"].contrast_limits
         """Opens an image and updates the image layer in the napari viewer."""
         if current_item is None:
             return  # If there is no current item selected, exit
-
         image_file = current_item.text()
         image = skimage.io.imread(image_file)
         rgb = image.shape[-1] in (3, 4)
@@ -296,6 +318,10 @@ class BboxQWidget(QWidget):
         classes = []
 
         class_file = os.path.dirname(image_file) + "/class.yaml"
+        current_class = "none"
+        if self.classlistWidget.currentItem():
+            current_class = self.classlistWidget.currentItem().text()
+        print("current_class: ", current_class)
         if os.path.isfile(class_file):
             with open(class_file) as file:
                 class_data_from_yaml = yaml.safe_load(file)
@@ -316,6 +342,10 @@ class BboxQWidget(QWidget):
             self.sort_classlist()
         items_text = [self.classlistWidget.item(i).text() for i in range(self.classlistWidget.count())]
         self.numbers = [int(name.split(":")[0]) for name in items_text]
+        for row in range(self.classlistWidget.count()):
+            item = self.classlistWidget.item(row)
+            if item.text() == current_class:
+                self.classlistWidget.setCurrentItem(item)
 
         items_dict_with_no = {
             item_text.split(":")[0].strip(): item_text.split(":")[1].strip() for item_text in items_text
@@ -353,16 +383,16 @@ class BboxQWidget(QWidget):
         else:
             shapes_layer = self.viewer.layers["bbox_layer"]
             shapes_layer.data = []
-
         self.viewer.reset_view()
+        self.dirty = False
 
     def saveAnnotations(self):
-        """Saves the bounding box annotations in the shapes layer in YOLO format."""
-
-        # Get the current image file name and the corresponding annotation file name
         current_image_file = self.listWidget.currentItem().text()
-        annotation_file = os.path.splitext(current_image_file)[0] + ".txt"
+        self.saveAnnotationsFor(current_image_file)
 
+    def saveAnnotationsFor(self, image_file):
+        """Saves the bounding box annotations in the shapes layer in YOLO format."""
+        annotation_file = os.path.splitext(image_file)[0] + ".txt"
         shapes_layer = self.viewer.layers["bbox_layer"]
         image_layer = self.viewer.layers["image_layer"]
         if image_layer.rgb:
@@ -412,6 +442,7 @@ class BboxQWidget(QWidget):
             prev_items_dict = yaml.safe_load(file)
         if prev_items_dict != class_data:
             self.check_file(class_file, class_data, file_type="classlist")
+        self.dirty = False
         self.update_list_colors_and_class_count()
 
     def check_file(self, filepath, file_str, file_type="annotations"):
@@ -426,7 +457,7 @@ class BboxQWidget(QWidget):
         if os.path.isfile(filepath):
             with open(filepath) as f:
                 if f.read() == file_str:
-                    self.show_saved_popup(popup, filepath, file_str, file_type)
+                    self.show_saved_notification(popup, filepath, file_str, file_type)
                 else:
                     if file_type == "annotations":
                         popup.setText("Do you want to overwrite the existing annotations?")
@@ -441,17 +472,15 @@ class BboxQWidget(QWidget):
                     )
                     popup.exec_()
         else:
-            self.show_saved_popup(popup, filepath, file_str, file_type)
+            self.show_saved_notification(popup, filepath, file_str, file_type)
 
     def on_popup_button_clicked_save(self, filepath, file_str, file_type, clicked_button):
         if clicked_button.text() == "Overwrite":
             save_text(filepath, file_str, file_type)
 
-    def show_saved_popup(self, popup, filepath, file_str, file_type):
+    def show_saved_notification(self, popup, filepath, file_str, file_type):
         save_text(filepath, file_str, file_type)
-        popup.setText(f"{file_type} saved")
-        popup.setStandardButtons(QMessageBox.Close)
-        popup.exec_()
+        napari.utils.notifications.show_info(f"{file_type} saved")
 
     def update_list_colors_and_class_count(self):
         self.class_counts = {}
@@ -471,9 +500,10 @@ class BboxQWidget(QWidget):
                     self.class_counts[class_id] = 0
                 self.class_counts[class_id] = self.class_counts[class_id] + 1
             item.setForeground(QBrush(QColorConstants.Green))
+            if item.isSelected() and self.dirty:
+                item.setForeground(QBrush(QColorConstants.Red))
         self.countListWidget.clear()
         counts = ['0'] * len(self.class_counts)
-        print("counts:", counts)
         self.countListWidget.addItems(counts)
         for key, value in self.class_counts.items():
             self.countListWidget.item(key).setText(str(value))

--- a/src/napari_simpleannotate/_bbox_widget.py
+++ b/src/napari_simpleannotate/_bbox_widget.py
@@ -18,6 +18,8 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from qtpy.QtGui import QBrush, QColorConstants
+
 
 from ._utils import find_missing_number, save_text, xywh2xyxy
 
@@ -29,6 +31,7 @@ class BboxQWidget(QWidget):
     def __init__(self, napari_viewer):
         super().__init__()
         self.viewer = napari_viewer
+        self.class_counts = {}
         self.initUI()
         self.initVariables()
         self.initLayers()
@@ -54,9 +57,15 @@ class BboxQWidget(QWidget):
         self.keep_contrast_checkbox = QCheckBox("Keep Contrast", self)
 
         # Create a list widget for displaying the list of classes
+        classListLayout = QHBoxLayout()
         self.classlistWidget = QListWidget()
         self.classlistWidget.setSelectionMode(QAbstractItemView.SingleSelection)
         self.classlistWidget.itemClicked.connect(self.class_clicked)
+        self.countListWidget = QListWidget()
+        self.countListWidget.setEnabled(False)
+        self.countListWidget.setMaximumWidth(40)
+        classListLayout.addWidget(self.classlistWidget)
+        classListLayout.addWidget(self.countListWidget)
 
         # Create text box for entering the class names
         self.class_textbox = QLineEdit()
@@ -83,7 +92,7 @@ class BboxQWidget(QWidget):
         layout.addWidget(self.listWidget)
         layout.addWidget(self.clear_button)
         layout.addWidget(self.keep_contrast_checkbox)
-        layout.addWidget(self.classlistWidget)
+        layout.addLayout(classListLayout)
         layout.addWidget(self.class_textbox)
         layout.addWidget(self.add_class_button)
         layout.addWidget(self.del_class_button)
@@ -145,6 +154,7 @@ class BboxQWidget(QWidget):
                     self.popup("numbering")
             class_name = f"{self.current_class_number}: {class_name}"
             self.classlistWidget.addItem(class_name)
+            self.countListWidget.addItem("0")
             self.sort_classlist()
             self.class_textbox.clear()
 
@@ -234,6 +244,7 @@ class BboxQWidget(QWidget):
             item = self.listWidget.findItems(fname[0], Qt.MatchExactly)[0]
             self.listWidget.setCurrentItem(item)
             self.open_image(item)
+        self.update_list_colors_and_class_count()
 
     def openDirectory(self):
         dname = QFileDialog.getExistingDirectory(self, "Open directory", "/")
@@ -242,6 +253,7 @@ class BboxQWidget(QWidget):
             image_files = sorted([f for f in files if f.endswith((".png", ".jpg", ".jpeg", ".tif", ".tiff"))])
             for image_file in image_files:
                 self.listWidget.addItem(os.path.join(dname, image_file))
+        self.update_list_colors_and_class_count()
 
     def popup_load_class(self, class_data_from_yaml):
         popup = QMessageBox(self)
@@ -400,6 +412,7 @@ class BboxQWidget(QWidget):
             prev_items_dict = yaml.safe_load(file)
         if prev_items_dict != class_data:
             self.check_file(class_file, class_data, file_type="classlist")
+        self.update_list_colors_and_class_count()
 
     def check_file(self, filepath, file_str, file_type="annotations"):
         popup = QMessageBox(self)
@@ -439,3 +452,29 @@ class BboxQWidget(QWidget):
         popup.setText(f"{file_type} saved")
         popup.setStandardButtons(QMessageBox.Close)
         popup.exec_()
+
+    def update_list_colors_and_class_count(self):
+        self.class_counts = {}
+        for row in range(self.listWidget.count()):
+            item = self.listWidget.item(row)
+            path = item.text()
+            annotationsPath = os.path.splitext(path)[0] + ".txt"
+            if not os.path.exists(annotationsPath):
+                continue
+            with open(annotationsPath, 'r') as file:
+                lines = file.readlines()
+            if len(lines) == 0:
+                continue
+            for line in lines:
+                class_id = int(line.split()[0])
+                if not class_id in self.class_counts.keys():
+                    self.class_counts[class_id] = 0
+                self.class_counts[class_id] = self.class_counts[class_id] + 1
+            item.setForeground(QBrush(QColorConstants.Green))
+        self.countListWidget.clear()
+        counts = ['0'] * len(self.class_counts)
+        print("counts:", counts)
+        self.countListWidget.addItems(counts)
+        for key, value in self.class_counts.items():
+            self.countListWidget.item(key).setText(str(value))
+


### PR DESCRIPTION
Bounding Box Annotation (YOLO format):
- Display images that have annotations with a different color in the list, so that the user can easily find them
- Keep the selected class when changing the image
- Bugfix: The class applied was sometimes different from the one selected in the list.
- When new annotations have been made on an image that did not have any before and the user changes the image, the message "annotations saved" is now displayed with the napari notification mechanism, instead of using a dialog. This avoids an unnecessary click to close the dialog.
- Changes to the display settings face_color, edge_color and edge_width are saved and loaded.
- Display the number of bounding boxes created for each class
- Ask if the user wants to save the annotations when he changes the image and there are unsaved changes